### PR TITLE
breadcrumbs mypage only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,5 +85,5 @@ gem 'erb2haml'
 gem "font-awesome-sass"
 gem 'fog-aws'
 gem 'faker'
-
+gem "gretel"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -353,6 +355,7 @@ DEPENDENCIES
   faker
   fog-aws
   font-awesome-sass
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -1,5 +1,5 @@
 .header{
-  height: 120px;
+  // height: 120px;
   padding: 5px 0 0 0;
   position:relative;
   box-shadow: 0 0 7px 0 rgba(0, 0, 0, 0.5);
@@ -37,6 +37,7 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
+      padding-bottom: 10px;
       &--left{
         display: flex;
         margin-top: 30px;
@@ -216,5 +217,23 @@
         }
       }
     }
-  
+    .breadcrumbs-frame{
+      border-top: solid 1px lighten(#00bfff,40%);
+      .breadcrumbs{
+        width: 800px;
+        height: 50px;
+        line-height: 50px;
+        margin: 0 auto;
+        background: #fff;
+        color: lighten(#000000,25%);
+        a{
+          text-decoration: none;
+          color: lighten(#000000,25%);
+        }
+        a:hover{
+          color: #00bfff;
+          border-bottom: solid 1px #00bfff;
+        }
+      }
+  }
 }

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -50,3 +50,6 @@
           = link_to "新規登録", new_user_registration_path, class: "sign-up-btn"
         .login
           = link_to "ログイン", new_user_session_path, class: "login-btn"
+
+  .breadcrumbs-frame
+    = breadcrumbs pretext: "",separator: " &raquo; "

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,3 +1,5 @@
+- breadcrumb :mypage
+
 = render "shared/header"
 
 .user-page

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,33 @@
+crumb :root do
+  link "ホーム", root_path
+end
+
+crumb :mypage do
+  link "マイページ", user_path
+  parent :root
+end
+  
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
#What
- パンくずリストの実装
- ホームとマイページを繋いだことのみ
- カテゴリー・出品一覧等、その他リストは未実装

#Why
- ユーザーが今いるページの位置を確認しやすくするため
- 他ページが未実装なため